### PR TITLE
[feat] Dragon API를 통해 챔피언 이름 추가

### DIFF
--- a/src/main/java/project/lolmonitor/application/controller/RiotController.java
+++ b/src/main/java/project/lolmonitor/application/controller/RiotController.java
@@ -1,5 +1,9 @@
 package project.lolmonitor.application.controller;
 
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -8,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import project.lolmonitor.service.riot.ChampionService;
 import project.lolmonitor.service.riot.RiotService;
 
 @RestController
@@ -16,6 +21,7 @@ import project.lolmonitor.service.riot.RiotService;
 public class RiotController {
 
 	private final RiotService riotService;
+	private final ChampionService championService;
 
 	/**
 	 * 라이엇 유저 DB에 추가 및 현재 게임 중 상태 확인
@@ -48,5 +54,27 @@ public class RiotController {
 
 		riotService.disableRiotUserMonitoring(gameNickname, tagLine);
 		return ResponseEntity.ok().build();
+	}
+
+	/**
+	 * 챔피언 데이터 동기화 실행
+	 */
+	@PostMapping("/sync")
+	public ResponseEntity<Map<String, Object>> syncChampions() {
+		try {
+			championService.syncChampionsFromApi();
+
+			Map<String, Object> result = new HashMap<>();
+			result.put("success", true);
+			result.put("message", "챔피언 데이터 동기화 완료");result.put("timestamp", LocalDateTime.now());
+
+			return ResponseEntity.ok(result);
+		} catch (Exception e) {
+			Map<String, Object> error = new HashMap<>();
+			error.put("success", false);
+			error.put("message", "동기화 실패: " + e.getMessage());
+
+			return ResponseEntity.status(500).body(error);
+		}
 	}
 }

--- a/src/main/java/project/lolmonitor/application/controller/RiotController.java
+++ b/src/main/java/project/lolmonitor/application/controller/RiotController.java
@@ -21,9 +21,9 @@ public class RiotController {
 	 * 라이엇 유저 DB에 추가 및 현재 게임 중 상태 확인
 	 */
 	@GetMapping
-	public ResponseEntity<String> checkGameStatus(@RequestParam String gameNickName, @RequestParam String tagLine) {
-		riotService.checkGameStatus(gameNickName, tagLine);
-		return ResponseEntity.ok("✅ " + gameNickName + "#" + tagLine + " 상태 확인 완료");
+	public ResponseEntity<String> checkGameStatus(@RequestParam String gameNickname, @RequestParam String tagLine) {
+		riotService.checkGameStatus(gameNickname, tagLine);
+		return ResponseEntity.ok("✅ " + gameNickname + "#" + tagLine + " 상태 확인 완료");
 	}
 
 	/**

--- a/src/main/java/project/lolmonitor/client/riot/api/RiotChampionApi.java
+++ b/src/main/java/project/lolmonitor/client/riot/api/RiotChampionApi.java
@@ -1,0 +1,28 @@
+package project.lolmonitor.client.riot.api;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
+
+import project.lolmonitor.client.riot.dto.ChampionData;
+
+/**
+ * https://ddragon.leagueoflegends.com
+ * Data Dragon APi 호출
+ * 리그오브레전드 챔피언 정보 가져오기
+ */
+public interface RiotChampionApi {
+
+	/**
+	 * 최신 버전 목록 조회
+	 */
+	@GetExchange("/api/versions.json")
+	List<String> getVersions();
+
+	/**
+	 * 챔피언 데이터 조회 (한국어)
+	 */
+	@GetExchange("/cdn/{version}/data/ko_KR/champion.json")
+	ChampionData getChampionData(@PathVariable String version);
+}

--- a/src/main/java/project/lolmonitor/client/riot/config/RiotApiConfig.java
+++ b/src/main/java/project/lolmonitor/client/riot/config/RiotApiConfig.java
@@ -7,9 +7,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
-import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
@@ -20,6 +18,7 @@ import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
 import lombok.extern.slf4j.Slf4j;
 import project.lolmonitor.client.riot.api.RiotAccountApi;
+import project.lolmonitor.client.riot.api.RiotChampionApi;
 import project.lolmonitor.client.riot.api.RiotSpectatorApi;
 
 @Slf4j
@@ -53,6 +52,15 @@ public class RiotApiConfig {
 	}
 
 	@Bean
+	public RestClient riotChampionRestClient() {
+		return RestClient.builder()
+			.baseUrl("https://ddragon.leagueoflegends.com")
+			.requestFactory(riotClientHttpRequestFactory())
+			.requestInterceptor(this::logRequest)
+			.build();
+	}
+
+	@Bean
 	public RiotAccountApi riotAccountApi(@Qualifier("riotAccountRestClient") RestClient riotAccountRestClient) {
 		var adapter = RestClientAdapter.create(riotAccountRestClient);
 		var proxy = HttpServiceProxyFactory.builderFor(adapter).build();
@@ -64,6 +72,13 @@ public class RiotApiConfig {
 		var adapter = RestClientAdapter.create(riotSpectatorRestClient);
 		var proxy = HttpServiceProxyFactory.builderFor(adapter).build();
 		return proxy.createClient(RiotSpectatorApi.class);
+	}
+
+	@Bean
+	public RiotChampionApi riotChampionApi(@Qualifier("riotChampionRestClient") RestClient riotChampionRestClient) {
+		var adapter = RestClientAdapter.create(riotChampionRestClient);
+		var proxy = HttpServiceProxyFactory.builderFor(adapter).build();
+		return proxy.createClient(RiotChampionApi.class);
 	}
 
 	@Bean

--- a/src/main/java/project/lolmonitor/client/riot/dto/ChampionBasicInfo.java
+++ b/src/main/java/project/lolmonitor/client/riot/dto/ChampionBasicInfo.java
@@ -1,0 +1,12 @@
+package project.lolmonitor.client.riot.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ChampionBasicInfo(
+	@JsonProperty("version") String version,
+	@JsonProperty("id") String id,
+	@JsonProperty("key") String key,
+	@JsonProperty("name") String name,
+	@JsonProperty("title") String title
+) {
+}

--- a/src/main/java/project/lolmonitor/client/riot/dto/ChampionData.java
+++ b/src/main/java/project/lolmonitor/client/riot/dto/ChampionData.java
@@ -1,0 +1,13 @@
+package project.lolmonitor.client.riot.dto;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ChampionData(
+	@JsonProperty("type") String type,
+	@JsonProperty("format") String format,
+	@JsonProperty("version") String version,
+	@JsonProperty("data") Map<String, ChampionBasicInfo> data
+) {
+}

--- a/src/main/java/project/lolmonitor/infra/riot/datahandler/ChampionDataHandler.java
+++ b/src/main/java/project/lolmonitor/infra/riot/datahandler/ChampionDataHandler.java
@@ -1,0 +1,47 @@
+package project.lolmonitor.infra.riot.datahandler;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import project.lolmonitor.infra.riot.entity.Champion;
+import project.lolmonitor.infra.riot.repository.ChampionRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChampionDataHandler {
+
+	private final ChampionRepository championRepository;
+
+	@Transactional(readOnly = true)
+	public String getChampionName(String championKey) {
+		Champion champion = championRepository.findByChampionKey(championKey)
+											  .orElseThrow(() -> new RuntimeException("챔피언을 찾을 수 없습니다. : " + championKey));
+		return champion.getChampionName();
+	}
+
+	@Transactional(readOnly = true)
+	public boolean existsChampion(String championKey) {
+		return championRepository.existsByChampionKey(championKey);
+	}
+
+	@Transactional
+	public void createChampion(String championKey, String championName) {
+		if (championRepository.existsByChampionKey(championKey)) {
+			log.info("이미 존재하는 챔피언 : {}, championKey : {}", championName, championKey);
+			return;
+		}
+
+		Champion champion = Champion.createChampion(championKey, championName);
+		championRepository.save(champion);
+	}
+
+	@Transactional
+	public void updateChampion(String championKey, String championName) {
+		Champion champion = championRepository.findByChampionKey(championKey)
+											  .orElseThrow(() -> new RuntimeException("챔피언을 찾을 수 없습니다. : " + championKey));
+		champion.updateChampion(championKey, championName);
+	}
+}

--- a/src/main/java/project/lolmonitor/infra/riot/entity/Champion.java
+++ b/src/main/java/project/lolmonitor/infra/riot/entity/Champion.java
@@ -1,0 +1,48 @@
+package project.lolmonitor.infra.riot.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.lolmonitor.infra.common.BaseEntity;
+
+@Table(name = "champion")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Champion extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "champion_key", nullable = false, unique = true)
+	private String championKey;
+
+	@Column(name = "champion_name")
+	private String championName;
+
+	@Builder
+	private Champion(String championKey, String championName) {
+		this.championKey = championKey;
+		this.championName = championName;
+	}
+
+	public static Champion createChampion(String championKey, String championName) {
+		return Champion.builder()
+			.championKey(championKey)
+			.championName(championName)
+			.build();
+	}
+
+	public void updateChampion(String championKey, String championName) {
+		this.championKey = championKey;
+		this.championName = championName;
+	}
+}

--- a/src/main/java/project/lolmonitor/infra/riot/repository/ChampionRepository.java
+++ b/src/main/java/project/lolmonitor/infra/riot/repository/ChampionRepository.java
@@ -1,0 +1,14 @@
+package project.lolmonitor.infra.riot.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import project.lolmonitor.infra.riot.entity.Champion;
+
+public interface ChampionRepository extends JpaRepository<Champion, Long> {
+
+	Optional<Champion> findByChampionKey(String championKey);
+
+	boolean existsByChampionKey(String championKey);
+}

--- a/src/main/java/project/lolmonitor/service/notification/NotificationService.java
+++ b/src/main/java/project/lolmonitor/service/notification/NotificationService.java
@@ -8,14 +8,16 @@ import org.springframework.web.client.RestClient;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import project.lolmonitor.infra.riot.datahandler.ChampionDataHandler;
 import project.lolmonitor.infra.riot.entity.GameSession;
 
-@Service
 @Slf4j
+@Service
 @RequiredArgsConstructor
 public class NotificationService {
 
 	private final RestClient restClient;
+	private final ChampionDataHandler championDataHandler;
 
 	@Value("${discord.url}")
 	private String discordUrl;
@@ -36,6 +38,7 @@ public class NotificationService {
             
             📍 **게임 정보**
             • 게임 모드 : %s
+            • 챔피언 : %s
             • 팀 : %s
             • 경과 시간 : %d분
             
@@ -43,10 +46,20 @@ public class NotificationService {
             """,
 			playerName,
 			getGameModeKorean(gameSession.getGameMode()),
+			getChampionName(String.valueOf(gameSession.getChampionId())),
 			gameSession.getTeamId() == 100L ? "🔵 블루" : "🔴 레드",
 			gameSession.getGameLength() > 0 ? gameSession.getGameLength() / 60 : 0,
 			playerName.replace("#", "-")
 		);
+	}
+
+	private String getChampionName(String championKey) {
+		String championName = championDataHandler.getChampionName(championKey);
+		if (championName == null || championName.isEmpty()) {
+			return "";
+		}
+
+		return championName;
 	}
 
 	private String getGameModeKorean(String gameMode) {

--- a/src/main/java/project/lolmonitor/service/riot/ChampionService.java
+++ b/src/main/java/project/lolmonitor/service/riot/ChampionService.java
@@ -1,0 +1,64 @@
+package project.lolmonitor.service.riot;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import project.lolmonitor.client.riot.api.RiotChampionApi;
+import project.lolmonitor.client.riot.dto.ChampionBasicInfo;
+import project.lolmonitor.client.riot.dto.ChampionData;
+import project.lolmonitor.infra.riot.datahandler.ChampionDataHandler;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChampionService {
+
+	private final RiotChampionApi riotChampionApi;
+	private final ChampionDataHandler championDataHandler;
+
+	public void syncChampionsFromApi() {
+		log.info("🔄 챔피언 데이터 동기화 시작...");
+
+		try {
+			// 1단계: 최신 버전 조회
+			List<String> versions = riotChampionApi.getVersions();
+			String latestVersion = versions.getFirst();
+			log.info("📦 최신 버전: {}", latestVersion);
+
+			// 2단계: 챔피언 전체 데이터 조회
+			ChampionData response = riotChampionApi.getChampionData(latestVersion);
+			Map<String, ChampionBasicInfo> championMap = response.data();
+			log.info("📊 조회된 챔피언 수: {}", championMap.size());
+
+			// 3단계: Map 데이터를 DB에 저장
+			int newCount = 0;
+			int updatedCount = 0;
+
+			for (ChampionBasicInfo championInfo : championMap.values()) {
+				String championKey = championInfo.key();
+				String championName = championInfo.name();
+
+				if (championDataHandler.existsChampion(championKey)) {
+					// 기존 챔피언 업데이트 (이름이 변경되었을 수도 있음)
+					championDataHandler.updateChampion(championKey, championName);
+					updatedCount++;
+				} else {
+					// 새로운 챔피언 추가
+					championDataHandler.createChampion(championKey, championName);
+					newCount++;
+				}
+			}
+
+			log.info("✅ 챔피언 데이터 동기화 완료: 신규 {}개, 업데이트 {}개, 버전: {}",
+				newCount, updatedCount, latestVersion);
+
+		} catch (Exception e) {
+			log.error("❌ 챔피언 데이터 동기화 실패: {}", e.getMessage());
+			throw e;
+		}
+	}
+}

--- a/src/main/java/project/lolmonitor/service/riot/RiotService.java
+++ b/src/main/java/project/lolmonitor/service/riot/RiotService.java
@@ -71,6 +71,7 @@ public class RiotService {
 		}
 	}
 
+	// 현재 게임 상태 확인
 	private void checkCurrentGameStatus(String playerDisplayName, String puuid) {
 		try {
 			// 게임 중 상태 확인 API 호출 (200: 게임 중, 404: 게임 중이 아님)
@@ -89,6 +90,7 @@ public class RiotService {
 		}
 	}
 
+	// 게임 중인지 확인
 	private void handleGameInProgress(String playerDisplayName, CurrentGameInfo currentGame, String puuid) {
 		boolean gameProgressStatus = gameSessionDataHandler.existsGameSession(currentGame.gameId());
 
@@ -116,7 +118,7 @@ public class RiotService {
 		}
 	}
 
-
+	// 현재 게임 중인 플레이어와 모니터링하는 플레이어 명이 일치한지
 	private CurrentGameParticipant findPlayerInGame(CurrentGameInfo currentGame, String puuid) {
 		return currentGame.participants().stream()
 						  .filter(p -> puuid.equals(p.puuid()))

--- a/src/main/java/project/lolmonitor/service/scheduler/RiotMonitorScheduler.java
+++ b/src/main/java/project/lolmonitor/service/scheduler/RiotMonitorScheduler.java
@@ -1,7 +1,6 @@
 package project.lolmonitor.service.scheduler;
 
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -23,7 +22,7 @@ public class RiotMonitorScheduler {
 	/**
 	 * 주기적으로 모니터링 대상 플레이어 게임 상태 확인
 	 */
-	@Scheduled(fixedDelayString = "60000")
+	@Scheduled(fixedDelayString = "30000")
 	public void checkAllPlayers() {
 		List<RiotUser> riotUsers = riotUserDataHandler.getMonitorRiotUsers();
 


### PR DESCRIPTION
## 구현 기능
- Data Dragon API 호출하여 전체 챔피언 DB에 저장
- championId를 통해 챔피언 이름 데이터 획득 가능
- 디스코드 메시지에 챔피언 이름 추가
- 스케줄링 시간 60초 -> 30초로 변경

## 예정 사항
- aws ec2 연결