### PR TITLE
[feat] 레벨 업 감지 알림, 게임 종료 시간 측정 로직 추가

### DIFF
--- a/src/main/java/project/lolmonitor/application/controller/RiotController.java
+++ b/src/main/java/project/lolmonitor/application/controller/RiotController.java
@@ -12,23 +12,38 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import project.lolmonitor.infra.riot.entity.RiotUser;
 import project.lolmonitor.service.riot.ChampionService;
-import project.lolmonitor.service.riot.RiotService;
+import project.lolmonitor.service.riot.GameStatusService;
+import project.lolmonitor.service.riot.RiotUserService;
+import project.lolmonitor.service.riot.SummonerLevelService;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/riot")
 public class RiotController {
 
-	private final RiotService riotService;
+	private final RiotUserService riotUserService;
+	private final GameStatusService gameStatusService;
 	private final ChampionService championService;
+	private final SummonerLevelService summonerLevelService;
 
 	/**
 	 * 라이엇 유저 DB에 추가 및 현재 게임 중 상태 확인
 	 */
 	@GetMapping
 	public ResponseEntity<String> checkGameStatus(@RequestParam String gameNickname, @RequestParam String tagLine) {
-		riotService.checkGameStatus(gameNickname, tagLine);
+		gameStatusService.checkGameStatus(gameNickname, tagLine);
+		return ResponseEntity.ok("✅ " + gameNickname + "#" + tagLine + " 상태 확인 완료");
+	}
+
+	/**
+	 * 레벨 업 확인
+	 */
+	@GetMapping("/level-up")
+	public ResponseEntity<String> checkLevelUp(@RequestParam String gameNickname, @RequestParam String tagLine) {
+		RiotUser riotUser = riotUserService.getRiotUser(gameNickname, tagLine);
+		summonerLevelService.checkSummonerLevel(riotUser);
 		return ResponseEntity.ok("✅ " + gameNickname + "#" + tagLine + " 상태 확인 완료");
 	}
 
@@ -40,7 +55,7 @@ public class RiotController {
 		@RequestParam String gameNickname,
 		@RequestParam String tagLine) {
 
-		riotService.enableRiotUserMonitoring(gameNickname, tagLine);
+		riotUserService.enableRiotUserMonitoring(gameNickname, tagLine);
 		return ResponseEntity.ok().build();
 	}
 
@@ -52,7 +67,7 @@ public class RiotController {
 		@RequestParam String gameNickname,
 		@RequestParam String tagLine) {
 
-		riotService.disableRiotUserMonitoring(gameNickname, tagLine);
+		riotUserService.disableRiotUserMonitoring(gameNickname, tagLine);
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/project/lolmonitor/client/riot/api/RiotAsiaApi.java
+++ b/src/main/java/project/lolmonitor/client/riot/api/RiotAsiaApi.java
@@ -4,13 +4,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.service.annotation.GetExchange;
 
 import project.lolmonitor.client.riot.dto.Account;
-import project.lolmonitor.client.riot.dto.CurrentGameInfo;
 
 /**
- * https://developer.riotgames.com/apis#account-v1
- * account에서 사용되는 api
+ * https://asia.api.riotgames.com
  */
-public interface RiotAccountApi {
+public interface RiotAsiaApi {
 
 	// 사용자 정보 조회 (puuid 획득 용도)
 	@GetExchange("/riot/account/v1/accounts/by-riot-id/{gameName}/{tagLine}")

--- a/src/main/java/project/lolmonitor/client/riot/api/RiotDataDragonApi.java
+++ b/src/main/java/project/lolmonitor/client/riot/api/RiotDataDragonApi.java
@@ -9,10 +9,10 @@ import project.lolmonitor.client.riot.dto.ChampionData;
 
 /**
  * https://ddragon.leagueoflegends.com
- * Data Dragon APi 호출
- * 리그오브레전드 챔피언 정보 가져오기
+ * Data Dragon API 호출
+ * 리그 오브 레전드 챔피언 정보 가져오기
  */
-public interface RiotChampionApi {
+public interface RiotDataDragonApi {
 
 	/**
 	 * 최신 버전 목록 조회

--- a/src/main/java/project/lolmonitor/client/riot/api/RiotKoreaApi.java
+++ b/src/main/java/project/lolmonitor/client/riot/api/RiotKoreaApi.java
@@ -1,18 +1,21 @@
 package project.lolmonitor.client.riot.api;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.service.annotation.GetExchange;
 
 import project.lolmonitor.client.riot.dto.CurrentGameInfo;
+import project.lolmonitor.client.riot.dto.Summoner;
 
 /**
- * https://developer.riotgames.com/apis#spectator-v5
- * spectator에서 사용되는 api
+ * https://kr.api.riotgames.com
  */
-public interface RiotSpectatorApi {
+public interface RiotKoreaApi {
 
 	// 게임 중 상태 확인 (실시간 게임 중인지 확인)
 	@GetExchange("/lol/spectator/v5/active-games/by-summoner/{encryptedPUUID}")
 	CurrentGameInfo getCurrentGameBySummoner(@PathVariable String encryptedPUUID);
+
+	// 소환사 레벨 정보 확인
+	@GetExchange("/lol/summoner/v4/summoners/by-puuid/{encryptedPUUID}")
+	Summoner getSummoner(@PathVariable String encryptedPUUID);
 }

--- a/src/main/java/project/lolmonitor/client/riot/config/RiotApiConfig.java
+++ b/src/main/java/project/lolmonitor/client/riot/config/RiotApiConfig.java
@@ -17,9 +17,9 @@ import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
 import lombok.extern.slf4j.Slf4j;
-import project.lolmonitor.client.riot.api.RiotAccountApi;
-import project.lolmonitor.client.riot.api.RiotChampionApi;
-import project.lolmonitor.client.riot.api.RiotSpectatorApi;
+import project.lolmonitor.client.riot.api.RiotAsiaApi;
+import project.lolmonitor.client.riot.api.RiotDataDragonApi;
+import project.lolmonitor.client.riot.api.RiotKoreaApi;
 
 @Slf4j
 @Configuration
@@ -32,7 +32,7 @@ public class RiotApiConfig {
 	private static final Duration READ_TIMEOUT = Duration.ofSeconds(10);
 
 	@Bean
-	public RestClient riotAccountRestClient() {
+	public RestClient riotAsiaRestClient() {
 		return RestClient.builder()
 			.baseUrl("https://asia.api.riotgames.com")
 			.defaultHeader("X-Riot-Token", riotApiKey)
@@ -42,7 +42,7 @@ public class RiotApiConfig {
 	}
 
 	@Bean
-	public RestClient riotSpectatorRestClient() {
+	public RestClient riotKoreaRestClient() {
 		return RestClient.builder()
 			.baseUrl("https://kr.api.riotgames.com")
 			.defaultHeader("X-Riot-Token", riotApiKey)
@@ -52,7 +52,7 @@ public class RiotApiConfig {
 	}
 
 	@Bean
-	public RestClient riotChampionRestClient() {
+	public RestClient riotDataDragonRestClient() {
 		return RestClient.builder()
 			.baseUrl("https://ddragon.leagueoflegends.com")
 			.requestFactory(riotClientHttpRequestFactory())
@@ -61,24 +61,24 @@ public class RiotApiConfig {
 	}
 
 	@Bean
-	public RiotAccountApi riotAccountApi(@Qualifier("riotAccountRestClient") RestClient riotAccountRestClient) {
-		var adapter = RestClientAdapter.create(riotAccountRestClient);
+	public RiotAsiaApi riotAsiaApi(@Qualifier("riotAsiaRestClient") RestClient riotAsiaRestClient) {
+		var adapter = RestClientAdapter.create(riotAsiaRestClient);
 		var proxy = HttpServiceProxyFactory.builderFor(adapter).build();
-		return proxy.createClient(RiotAccountApi.class);
+		return proxy.createClient(RiotAsiaApi.class);
 	}
 
 	@Bean
-	public RiotSpectatorApi riotSpectatorApi(@Qualifier("riotSpectatorRestClient") RestClient riotSpectatorRestClient) {
-		var adapter = RestClientAdapter.create(riotSpectatorRestClient);
+	public RiotKoreaApi riotKoreaApi(@Qualifier("riotKoreaRestClient") RestClient riotKoreaRestClient) {
+		var adapter = RestClientAdapter.create(riotKoreaRestClient);
 		var proxy = HttpServiceProxyFactory.builderFor(adapter).build();
-		return proxy.createClient(RiotSpectatorApi.class);
+		return proxy.createClient(RiotKoreaApi.class);
 	}
 
 	@Bean
-	public RiotChampionApi riotChampionApi(@Qualifier("riotChampionRestClient") RestClient riotChampionRestClient) {
-		var adapter = RestClientAdapter.create(riotChampionRestClient);
+	public RiotDataDragonApi riotChampionApi(@Qualifier("riotDataDragonRestClient") RestClient riotDataDragonRestClient) {
+		var adapter = RestClientAdapter.create(riotDataDragonRestClient);
 		var proxy = HttpServiceProxyFactory.builderFor(adapter).build();
-		return proxy.createClient(RiotChampionApi.class);
+		return proxy.createClient(RiotDataDragonApi.class);
 	}
 
 	@Bean

--- a/src/main/java/project/lolmonitor/client/riot/dto/Summoner.java
+++ b/src/main/java/project/lolmonitor/client/riot/dto/Summoner.java
@@ -1,0 +1,19 @@
+package project.lolmonitor.client.riot.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Summoner(
+	// Encrypted PUUID. Exact length of 78 characters.
+	@JsonProperty("puuid") String puuid,
+
+	// ID of the summoner icon associated with the summoner.
+	@JsonProperty("profileIconId") int profileIconId,
+
+	// Date summoner was last modified specified as epoch milliseconds.
+	// The following events will update this timestamp: profile icon change, playing the tutorial or advanced tutorial, finishing a game, summoner name change.
+	@JsonProperty("revisionDate") Long revisionDate,
+
+	// Summoner level associated with the summoner.
+	@JsonProperty("summonerLevel") Long summonerLevel
+) {
+}

--- a/src/main/java/project/lolmonitor/common/enums/GameMode.java
+++ b/src/main/java/project/lolmonitor/common/enums/GameMode.java
@@ -1,0 +1,42 @@
+package project.lolmonitor.common.enums;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GameMode {
+	CLASSIC("CLASSIC", "소환사의 협곡"),
+	ARAM("ARAM", "무작위 총력전"),
+	URF("URF", "우르프"),
+	ONEFORALL("ONEFORALL", "원 포 올"),
+	NEXUSBLITZ("NEXUSBLITZ", "넥서스 블리츠"),
+	CHERRY("CHERRY", "아레나"),
+	UNKNOWN("UNKNOWN", "알 수 없는 모드");
+
+	private final String code;
+	private final String koreanName;
+
+	/**
+	 * 코드로 GameMode 찾기
+	 */
+	public static GameMode fromCode(String code) {
+		if (code == null) {
+			return UNKNOWN;
+		}
+
+		return Arrays.stream(values())
+					 .filter(mode -> mode.code.equals(code))
+					 .findFirst()
+					 .orElse(UNKNOWN);
+	}
+
+	/**
+	 * 한국어 이름 반환 (null safe)
+	 */
+	public static String getKoreanName(String code) {
+		return fromCode(code).getKoreanName();
+	}
+}

--- a/src/main/java/project/lolmonitor/common/enums/GameStatus.java
+++ b/src/main/java/project/lolmonitor/common/enums/GameStatus.java
@@ -1,4 +1,4 @@
-package project.lolmonitor.infra.riot.entity;
+package project.lolmonitor.common.enums;
 
 public enum GameStatus {
 	IN_PROGRESS,    // 진행 중

--- a/src/main/java/project/lolmonitor/infra/riot/datahandler/SummonerLevelHistoryDataHandler.java
+++ b/src/main/java/project/lolmonitor/infra/riot/datahandler/SummonerLevelHistoryDataHandler.java
@@ -1,0 +1,77 @@
+package project.lolmonitor.infra.riot.datahandler;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import project.lolmonitor.infra.riot.entity.RiotUser;
+import project.lolmonitor.infra.riot.entity.SummonerLevelHistory;
+import project.lolmonitor.infra.riot.repository.SummonerLevelHistoryRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SummonerLevelHistoryDataHandler {
+
+	private final SummonerLevelHistoryRepository levelHistoryRepository;
+
+	/**
+	 * 마지막 레벨업 이력 조회
+	 */
+	@Transactional(readOnly = true)
+	public SummonerLevelHistory getLatestLevelHistory(RiotUser riotUser) {
+		return levelHistoryRepository.findTopByRiotUserOrderByLevelUpTimeDesc(riotUser)
+									 .orElseThrow(() -> new RuntimeException("존재하지 않는 레벨 히스토리"));
+	}
+
+	/**
+	 * 마지막으로 기록된 레벨 조회
+	 */
+	@Transactional(readOnly = true)
+	public int getLastRecordedLevel(RiotUser riotUser) {
+		return levelHistoryRepository.findTopByRiotUserOrderByLevelUpTimeDesc(riotUser)
+									 .map(SummonerLevelHistory::getLevel)
+									 .orElse(0); // 첫 기록이면 0으로 시작
+	}
+
+	/**
+	 * 마지막 레벨업 시간 조회
+	 */
+	@Transactional(readOnly = true)
+	public LocalDateTime getLastLevelUpTime(RiotUser riotUser) {
+		return levelHistoryRepository.findTopByRiotUserOrderByLevelUpTimeDesc(riotUser)
+									 .map(SummonerLevelHistory::getLevelUpTime)
+									 .orElse(riotUser.getCreatedAt()); // 첫 레벨업이면 유저 생성 시간부터
+	}
+
+	/**
+	 * 레벨업 이력 저장
+	 */
+	@Transactional
+	public SummonerLevelHistory saveLevelHistory(RiotUser riotUser, int level, LocalDateTime levelUpTime,
+		int gamesPlayed, BigDecimal timeTaken) {
+		SummonerLevelHistory levelHistory = SummonerLevelHistory
+			.builder()
+			.riotUser(riotUser)
+			.level(level)
+			.levelUpTime(levelUpTime)
+			.gamesPlayedForLevelup(gamesPlayed)
+			.timeTakenHours(timeTaken)
+			.build();
+
+		return levelHistoryRepository.save(levelHistory);
+	}
+
+	/**
+	 * 특정 유저의 모든 레벨업 이력 조회 (최신순)
+	 */
+	@Transactional(readOnly = true)
+	public List<SummonerLevelHistory> getAllLevelHistories(RiotUser riotUser) {
+		return levelHistoryRepository.findByRiotUserOrderByLevelUpTimeDesc(riotUser);
+	}
+}

--- a/src/main/java/project/lolmonitor/infra/riot/entity/GameSession.java
+++ b/src/main/java/project/lolmonitor/infra/riot/entity/GameSession.java
@@ -1,7 +1,6 @@
 package project.lolmonitor.infra.riot.entity;
 
 import java.time.Duration;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
@@ -19,6 +18,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import project.lolmonitor.common.enums.GameStatus;
 import project.lolmonitor.infra.common.BaseEntity;
 
 @Table(name =  "game_session")
@@ -95,20 +95,15 @@ public class GameSession extends BaseEntity {
 			.build();
 	}
 
-	public long getDurationMinutes() {
-		LocalDateTime endTime = this.endTime != null ? this.endTime : LocalDateTime.now();
-		return Duration.between(startTime, endTime).toMinutes();
-	}
-
-	public boolean isStale() {
-		return getDurationMinutes() > 120; // 2시간 이상은 비정상
-	}
-
-	public LocalDate getGameDate() {
-		return startTime.toLocalDate();
-	}
-
-	public void updateEndTime(LocalDateTime endTime) {
+	public void endGame(LocalDateTime endTime) {
 		this.endTime = endTime;
+		this.gameStatus = GameStatus.COMPLETED;
+	}
+
+	public Duration getGameDuration() {
+		if (endTime == null) {
+			return Duration.between(startTime, LocalDateTime.now());
+		}
+		return Duration.between(startTime, endTime);
 	}
 }

--- a/src/main/java/project/lolmonitor/infra/riot/entity/SummonerLevelHistory.java
+++ b/src/main/java/project/lolmonitor/infra/riot/entity/SummonerLevelHistory.java
@@ -1,0 +1,68 @@
+package project.lolmonitor.infra.riot.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.lolmonitor.infra.common.BaseEntity;
+
+// 소환사 레벨 이력 테이블
+@Table(name = "summoner_level_history")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SummonerLevelHistory extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "riot_user_id", nullable = false)
+	private RiotUser riotUser;
+
+	@Column(name = "level", nullable = false)
+	private int level;
+
+	@Column(name = "level_up_time", nullable = false)
+	private LocalDateTime levelUpTime;
+
+	@Column(name = "games_played_for_levelup", nullable = false)
+	private int gamesPlayedForLevelup;
+
+	@Column(name = "time_taken_hours", nullable = false)
+	private BigDecimal timeTakenHours;
+
+	@Builder
+	private SummonerLevelHistory(RiotUser riotUser, int level, LocalDateTime levelUpTime,
+		int gamesPlayedForLevelup, BigDecimal timeTakenHours) {
+		this.riotUser = riotUser;
+		this.level = level;
+		this.levelUpTime = levelUpTime;
+		this.gamesPlayedForLevelup = gamesPlayedForLevelup;
+		this.timeTakenHours = timeTakenHours;
+	}
+
+	public static SummonerLevelHistory createLevelHistory(RiotUser riotUser, int level,
+		LocalDateTime levelUpTime, int gamesPlayedForLevelup, BigDecimal timeTakenHours) {
+		return SummonerLevelHistory.builder()
+			.riotUser(riotUser)
+			.level(level)
+			.levelUpTime(levelUpTime)
+			.gamesPlayedForLevelup(gamesPlayedForLevelup)
+			.timeTakenHours(timeTakenHours)
+			.build();
+	}
+}

--- a/src/main/java/project/lolmonitor/infra/riot/repository/GameSessionRepository.java
+++ b/src/main/java/project/lolmonitor/infra/riot/repository/GameSessionRepository.java
@@ -1,18 +1,19 @@
 package project.lolmonitor.infra.riot.repository;
 
-import java.util.List;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import project.lolmonitor.infra.riot.entity.GameSession;
-import project.lolmonitor.infra.riot.entity.GameStatus;
-import project.lolmonitor.infra.riot.entity.RiotUser;
+import project.lolmonitor.common.enums.GameStatus;
 
 public interface GameSessionRepository extends JpaRepository<GameSession, Long> {
 
-	Optional<GameSession> findByRiotUserAndGameIdAndGameStatus(
-		RiotUser riotUser, Long gameId, GameStatus gameStatus);
+	Optional<GameSession> findByRiotUserPuuidAndGameStatus(
+		String puuid, GameStatus gameStatus);
+
+	int countByRiotUserIdAndGameStatusAndEndTimeAfter(Long riotUserId, GameStatus gameStatus, LocalDateTime since);
 
 	int countByRiotUserId(Long riotUserId);
 

--- a/src/main/java/project/lolmonitor/infra/riot/repository/SummonerLevelHistoryRepository.java
+++ b/src/main/java/project/lolmonitor/infra/riot/repository/SummonerLevelHistoryRepository.java
@@ -1,0 +1,16 @@
+package project.lolmonitor.infra.riot.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import project.lolmonitor.infra.riot.entity.RiotUser;
+import project.lolmonitor.infra.riot.entity.SummonerLevelHistory;
+
+public interface SummonerLevelHistoryRepository extends JpaRepository<SummonerLevelHistory, Long> {
+
+	Optional<SummonerLevelHistory> findTopByRiotUserOrderByLevelUpTimeDesc(RiotUser riotUser);
+
+	List<SummonerLevelHistory> findByRiotUserOrderByLevelUpTimeDesc(RiotUser riotUser);
+}

--- a/src/main/java/project/lolmonitor/service/riot/ChampionService.java
+++ b/src/main/java/project/lolmonitor/service/riot/ChampionService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import project.lolmonitor.client.riot.api.RiotChampionApi;
+import project.lolmonitor.client.riot.api.RiotDataDragonApi;
 import project.lolmonitor.client.riot.dto.ChampionBasicInfo;
 import project.lolmonitor.client.riot.dto.ChampionData;
 import project.lolmonitor.infra.riot.datahandler.ChampionDataHandler;
@@ -17,7 +17,7 @@ import project.lolmonitor.infra.riot.datahandler.ChampionDataHandler;
 @RequiredArgsConstructor
 public class ChampionService {
 
-	private final RiotChampionApi riotChampionApi;
+	private final RiotDataDragonApi riotDataDragonApi;
 	private final ChampionDataHandler championDataHandler;
 
 	public void syncChampionsFromApi() {
@@ -25,12 +25,12 @@ public class ChampionService {
 
 		try {
 			// 1단계: 최신 버전 조회
-			List<String> versions = riotChampionApi.getVersions();
+			List<String> versions = riotDataDragonApi.getVersions();
 			String latestVersion = versions.getFirst();
 			log.info("📦 최신 버전: {}", latestVersion);
 
 			// 2단계: 챔피언 전체 데이터 조회
-			ChampionData response = riotChampionApi.getChampionData(latestVersion);
+			ChampionData response = riotDataDragonApi.getChampionData(latestVersion);
 			Map<String, ChampionBasicInfo> championMap = response.data();
 			log.info("📊 조회된 챔피언 수: {}", championMap.size());
 

--- a/src/main/java/project/lolmonitor/service/riot/RiotUserService.java
+++ b/src/main/java/project/lolmonitor/service/riot/RiotUserService.java
@@ -1,0 +1,28 @@
+package project.lolmonitor.service.riot;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import project.lolmonitor.infra.riot.datahandler.RiotUserDataHandler;
+import project.lolmonitor.infra.riot.entity.RiotUser;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RiotUserService {
+
+	private final RiotUserDataHandler riotUserDataHandler;
+
+	public RiotUser getRiotUser(String gameNickName, String tagLine) {
+		return riotUserDataHandler.getRiotUser(gameNickName, tagLine);
+	}
+
+	public void enableRiotUserMonitoring(String gameNickName, String tagLine) {
+		riotUserDataHandler.enableRiotUserMonitoring(gameNickName, tagLine);
+	}
+
+	public void disableRiotUserMonitoring(String gameNickName, String tagLine) {
+		riotUserDataHandler.disableRiotUserMonitoring(gameNickName, tagLine);
+	}
+}

--- a/src/main/java/project/lolmonitor/service/riot/SummonerLevelService.java
+++ b/src/main/java/project/lolmonitor/service/riot/SummonerLevelService.java
@@ -1,0 +1,113 @@
+package project.lolmonitor.service.riot;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import project.lolmonitor.client.riot.api.RiotKoreaApi;
+import project.lolmonitor.client.riot.dto.Summoner;
+import project.lolmonitor.infra.riot.datahandler.GameSessionDataHandler;
+import project.lolmonitor.infra.riot.datahandler.SummonerLevelHistoryDataHandler;
+import project.lolmonitor.infra.riot.entity.RiotUser;
+import project.lolmonitor.infra.riot.entity.SummonerLevelHistory;
+import project.lolmonitor.service.notification.NotificationService;
+
+/**
+ * 소환사 레벨 업 확인하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SummonerLevelService {
+
+	private final RiotKoreaApi riotKoreaApi;
+	private final NotificationService notificationService;
+	private final SummonerLevelHistoryDataHandler levelHistoryDataHandler;
+	private final GameSessionDataHandler gameSessionDataHandler;
+
+	/**
+	 * 소환사 레벨 확인 및 레벨업 감지
+	 */
+	public void checkSummonerLevel(RiotUser riotUser) {
+		try {
+			log.info("📊 {}의 레벨 확인 중...", riotUser.getDisplayName());
+
+			// 1. 현재 API에서 레벨 조회
+			Summoner summoner = riotKoreaApi.getSummoner(riotUser.getPuuid());
+			int currentLevel = summoner.summonerLevel().intValue();
+
+			// 2. 마지막 기록된 레벨 조회
+			int lastRecordedLevel = levelHistoryDataHandler.getLastRecordedLevel(riotUser);
+
+			// 3. 첫 번째 레벨 기록인지 확인
+			boolean isFirstRecord = lastRecordedLevel == 0;
+
+			if (isFirstRecord) {
+				// 첫 기록: 현재 레벨을 기준점으로 저장 (레벨업 알림 없음)
+				handleFirstLevelRecord(riotUser, currentLevel);
+			} else if (currentLevel > lastRecordedLevel) {
+				// 실제 레벨업 감지
+				handleLevelUp(riotUser, lastRecordedLevel, currentLevel);
+			}
+
+		} catch (Exception e) {
+			log.error("❌ {} 레벨 확인 실패: {}", riotUser.getDisplayName(), e.getMessage());
+		}
+	}
+
+	/**
+	 * 레벨업 처리
+	 */
+	private void handleLevelUp(RiotUser riotUser, int previousLevel, int currentLevel) {
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime lastLevelUpTime = levelHistoryDataHandler.getLastLevelUpTime(riotUser);
+
+		BigDecimal timeTaken = calculateTimeTaken(lastLevelUpTime, now);
+		int gamesSinceLastLevelUp = countGamesSinceLastLevelUp(riotUser, lastLevelUpTime);
+
+		// 레벨업 이력 저장
+		SummonerLevelHistory levelHistory = levelHistoryDataHandler.saveLevelHistory(
+			riotUser, currentLevel, now, gamesSinceLastLevelUp, timeTaken);
+
+		// 디스코드 알림 전송
+		notificationService.sendLevelUpNotification(riotUser.getDisplayName(), previousLevel, levelHistory);
+
+		log.info("🎉 {} 레벨업! {} → {} ({}시간, {}판)",
+			riotUser.getDisplayName(), previousLevel, currentLevel, timeTaken, gamesSinceLastLevelUp);
+	}
+
+	/**
+	 * 첫 번째 레벨 기록 (알림 없음)
+	 */
+	private void handleFirstLevelRecord(RiotUser riotUser, int currentLevel) {
+		LocalDateTime now = LocalDateTime.now();
+
+		// 첫 기록이므로 시간과 게임 수는 0으로 설정
+		SummonerLevelHistory levelHistory = levelHistoryDataHandler.saveLevelHistory(
+			riotUser, currentLevel, now, 0, BigDecimal.ZERO);
+
+		log.info("🆕 {} 첫 레벨 기록: {}레벨", riotUser.getDisplayName(), currentLevel);
+	}
+
+	/**
+	 * 마지막 레벨업 이후 완료된 게임 수 카운트
+	 */
+	private int countGamesSinceLastLevelUp(RiotUser riotUser, LocalDateTime since) {
+		return gameSessionDataHandler.countCompletedGamesSince(riotUser.getId(), since);
+	}
+
+	/**
+	 * 레벨업에 소요된 시간 계산 (시간 단위)
+	 */
+	private BigDecimal calculateTimeTaken(LocalDateTime startTime, LocalDateTime endTime) {
+		Duration duration = Duration.between(startTime, endTime);
+		long totalSeconds = duration.getSeconds();
+		return BigDecimal.valueOf(totalSeconds)
+						 .divide(BigDecimal.valueOf(3600), 4, RoundingMode.HALF_UP); // 3600초 = 1시간
+	}
+}


### PR DESCRIPTION
## 구현 사항
- 소환사 정보 API를 이용하여 소환사 레벨 확인
  - 레벨 업 시, 디스코드 알림 발생
- 게임이 종료되는 경우, 종료 시간 측정 후 DB에 저장